### PR TITLE
Improve performance and UI

### DIFF
--- a/elscreen-tab--emacs27.el
+++ b/elscreen-tab--emacs27.el
@@ -1,0 +1,66 @@
+;;; elscreen-tab--emacs27.el --- helper function defined since Emacs27  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2020
+
+;; Author: Aki Syunsuke <sunny.day.dev@gmail.com>
+;; URL: https://github.com/aki-s/elscreen-tab
+;; Package-Version: 0.0.0
+;; Package-Requires: ((emacs "26"))
+;; Keywords: lisp
+;; Created: 2020-12-29
+;; Updated: 2020-12-29T13:10:07Z; # UTC
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Functions for backword compatibility of Emacs.
+
+;;; Code:
+
+
+(cond
+  ((string-lessp emacs-version "27.1")
+    (defun elscreen-tab--emacs27-window-state-buffers (state)
+      "Return all buffers saved to the given window state STATE."
+      ;; Accustom to the behavior of `window-state-get' of
+      ;; GNU Emacs 26.3 on Darwin.
+      ;; `window-state-get' returns buffer object on Emacs 27 instead.
+      (let ((buffer (cadr (assq 'buffer state)))
+             (buffers (mapcan (lambda (item)
+                                (when (memq (car item) '(leaf vc hc))
+                                  (elscreen-tab--emacs27-window-state-buffers item)))
+                        (if (consp (car state)) (list (cdr state)) (cdr state)))))
+        (if buffer (cons (get-buffer buffer) buffers) buffers))))
+  (t
+    (defalias #'elscreen-tab--emacs27-window-state-buffers #'window-state-buffers)))
+
+;;------------------------------------------------
+;; Unload function:
+
+(defun elscreen-tab-emacs27-unload-function ()
+   "Unload function to ensure normal behavior when feature 'elscreen-tab--emacs27 is unloaded."
+   (interactive))
+
+(provide 'elscreen-tab--emacs27)
+;;; elscreen-tab--emacs27.el ends here
+
+;; Local variables:
+;; eval: (add-hook 'write-file-functions 'time-stamp)
+;; time-stamp-start: ";; Updated:"
+;; time-stamp-format: " %:y-%02m-%02dT%02H:%02M:%02SZ"
+;; time-stamp-line-limit: 13
+;; time-stamp-time-zone: "UTC"
+;; time-stamp-end: "; # UTC"
+;; End:

--- a/elscreen-tab.el
+++ b/elscreen-tab.el
@@ -235,7 +235,7 @@ Alternative to `elscreen-display-tab'."
   "Return t if BUFFER is named `elscreen-tab--dedicated-tab-buffer-name'."
   (equal (buffer-name buffer) elscreen-tab--dedicated-tab-buffer-name))
 
-(defun elscreen-tab--tab-number ()
+(defun elscreen-tab--window-count ()
   "Window number (s) of currently displayed `elscreen-tab--dedicated-tab-buffer-name'."
   (-count #'elscreen-tab--elscreen-tab-name-p
           (mapcar #'window-buffer (window-list))))
@@ -244,7 +244,7 @@ Alternative to `elscreen-display-tab'."
   "Delete elscreen-tab if it is not side window.
 This case can happen if `desktop-read' is called."
   (elscreen-tab--debug-log "[%s>%s]called" this-command "elscreen-tab--ensure-one-window")
-  (when (= (elscreen-tab--tab-number) 1)
+  (when (= (elscreen-tab--window-count) 1)
     (cl-return-from elscreen-tab--ensure-one-window))
   (let* ((ignore-window-parameters t)
          (win-list (window-list)))
@@ -301,7 +301,7 @@ current visible display."
       (with-demoted-errors "Unable to minimize %s"
         (window-resize window delta-allowed nil t)
         (window-preserve-size window nil t)
-        (setq window-size-fixed t)
+        (setq window-size-fixed 'height)
         )))
   )
 

--- a/elscreen-tab.el
+++ b/elscreen-tab.el
@@ -8,6 +8,7 @@
 ;; Package-Requires: ((emacs "26") (elscreen "20180321") (dash "2.14.1"))
 ;; Keywords: tools, extensions
 ;; Created: 2017-02-26
+;; Updated: 2020-11-21T01:44:17Z;
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -443,3 +444,12 @@ Buffers having connected window are displayed first."
 
 (provide 'elscreen-tab)
 ;;; elscreen-tab.el ends here
+
+;; Local variables:
+;; eval: (add-hook 'write-file-functions 'time-stamp)
+;; time-stamp-start: ";; Updated:"
+;; time-stamp-format: " %:y-%02m-%02dT%02H:%02M:%02SZ"
+;; time-stamp-line-limit: 13
+;; time-stamp-time-zone: "UTC"
+;; time-stamp-end: ";"
+;; End:

--- a/elscreen-tab.el
+++ b/elscreen-tab.el
@@ -206,11 +206,10 @@ some command of `elscreen' would have failed ungracefully or there's a bug regar
           (mapconcat 'identity
             (if (or (> (window-text-width win) (* elscreen-tab--tab-unit-width (elscreen-get-number-of-screens)))
                   (memq elscreen-tab-position (list 'left 'right)))
-              (elscreen-tab--create-tab-units-static)
+              (progn (elscreen-tab--create-tab-units-static)
+                (elscreen-tab--move-pointer-to-selected-tab (elscreen-get-current-screen) (current-buffer)))
               (elscreen-tab--create-tab-units-abbreviated))
             sep)))
-      ;;fixme: pointer doesn't set at currently selected-tab when switched to the buffer.
-      (elscreen-tab--move-pointer-to-selected-tab (elscreen-get-current-screen) (current-buffer))
       (setq buffer-read-only t)))
   (setq elscreen-tab--last-frame-size (elscreen-tab--frame-size))
   (setq elscreen-tab--last-buffer-name (buffer-name))
@@ -224,9 +223,8 @@ some command of `elscreen' would have failed ungracefully or there's a bug regar
 (defun elscreen-tab--move-pointer-to-selected-tab (screen-id buffer)
   "Move point to selected SCREEN-ID in BUFFER of elscreen-tab."
   (with-current-buffer buffer
-    (goto-char (point-min))
-    ;; char is 1-indexed.
-    (goto-char (1+ (elscreen-tab--get-nth-from-left screen-id)))))
+    (goto-char (point-min)) ;; char is 1-indexed.
+    (right-char (* elscreen-tab--tab-unit-width (elscreen-tab--get-nth-from-left screen-id)))))
 
 (defun elscreen-tab--set-idle-timer-for-updating-display ()
   "Set idle timeer to update display for performance reason."

--- a/elscreen-tab.el
+++ b/elscreen-tab.el
@@ -56,7 +56,7 @@
 (require 'seq)
 (require 'elscreen)
 
-
+;; defgroup
 (defgroup elscreen-tab nil
   "Show tabs of elscreen in dedicated buffer.
 Alternative to `elscreen-display-tab'."
@@ -64,7 +64,7 @@ Alternative to `elscreen-display-tab'."
   :group 'elscreen
   :package-version '("elscreen-tab" "1.0.1"))
 
-
+;; defconst
 (defconst elscreen-tab--tab-window-parameters
   '(window-parameters .
                       ((no-other-window . t) (no-delete-other-windows . t) (delete-window . ignore))))
@@ -105,14 +105,14 @@ Alternative to `elscreen-display-tab'."
   :type 'number
   :group 'elscreen-tab)
 
-
+;; defvar
 (defvar elscreen-tab--mode-line-format nil "Remove mode-line for elscreen-tab if nil.")
 (defvar elscreen-tab-hooks '(elscreen-create-hook elscreen-goto-hook elscreen-kill-hook)
   "A group of hooks to update elscreen-tab.")
 (defvar elscreen-tab--display-idle-timer nil "Idle timer object to update display.")
 (defvar elscreen-tab--last-screen-id 0)
 
-
+;; defface
 (defface elscreen-tab-current-screen-face
   '((default :inherit header-line-highlight)
      (((class color))
@@ -139,7 +139,7 @@ Alternative to `elscreen-display-tab'."
        ))
   "Face for when mouse cursor is over each tab of elscreen.")
 
-
+;; defun
 (defun elscreen-tab--debug-log (form &rest args)
   "Logging function of the same format with (message FORM ARGS)."
   (when elscreen-tab-debug-flag (apply #'message (concat "[ELSCREEN-TAB]" form) args)))
@@ -396,8 +396,7 @@ HOOKS is such as '(hook1 hook2) or 'hook3."
     )
    ))
 
-
-;;;; Mode
+;;;; Mode
 ;;;###autoload
 (define-minor-mode elscreen-tab-mode
   "Show tab window of elscreen at `elscreen-tab-position' instead of 'header-line.
@@ -415,15 +414,16 @@ Because header line is precious and tab is only displayed in
            (setq elscreen-display-tab nil) ; Disable `tab' using header-line.
            (elscreen-tab--add-all-hooks)
            (elscreen-tab--update-and-display)
+           (elscreen-tab-toggle-move-frame-function t)
            )
           (t
            (elscreen-tab--remove-all-hooks) ; Delete side-effects.
            (elscreen-tab--clear-objects)
+           (elscreen-tab-toggle-move-frame-function nil)
            )))
   )
 
-
-;; Utility for debug:
+;; Utility for debug:
 (defun elscreen-tab--pp-buffer-and-window ()
   "Show each buffer name and its connected window.
 Buffers having connected window are displayed first."

--- a/elscreen-tab.el
+++ b/elscreen-tab.el
@@ -8,7 +8,7 @@
 ;; Package-Requires: ((emacs "26") (elscreen "20180321") (dash "2.14.1"))
 ;; Keywords: tools, extensions
 ;; Created: 2017-02-26
-;; Updated: 2020-12-29T13:39:07Z;
+;; Updated: 2020-12-29T14:07:36Z;
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -55,9 +55,8 @@
 (require 'dash)
 (require 'seq)
 (require 'elscreen)
-(eval-and-compile
-  (if (string-lessp emacs-version "27.1")
-    (require 'elscreen-tab--emacs27)))
+
+(require 'elscreen-tab--emacs27)
 
 ;; defgroup
 (defgroup elscreen-tab nil

--- a/elscreen-tab.el
+++ b/elscreen-tab.el
@@ -110,6 +110,7 @@ Alternative to `elscreen-display-tab'."
 (defvar elscreen-tab-hooks '(elscreen-create-hook elscreen-goto-hook elscreen-kill-hook)
   "A group of hooks to update elscreen-tab.")
 (defvar elscreen-tab--display-idle-timer nil "Idle timer object to update display.")
+(defvar elscreen-tab--last-screen-id 0)
 
 
 (defface elscreen-tab-current-screen-face
@@ -173,12 +174,13 @@ Alternative to `elscreen-display-tab'."
              (sep (gethash elscreen-tab-position elscreen-tab--tab-unit-separator "|")))
         (mapconcat #'elscreen-tab--create-tab-unit screen-ids sep)))
     ;; Finish
-    (setq buffer-read-only t)))
+    (setq buffer-read-only t))
+  (setq elscreen-tab--last-screen-id (elscreen-get-current-screen)))
 
 (defun elscreen-tab--set-idle-timer-for-updating-display ()
   (elscreen-tab--debug-log "[%s>%s]called" this-command "elscreen-tab--set-idle-timer-for-updating-display")
-  (elscreen-tab--debug-log "elscreen-tab--display-idle-timer:%s" elscreen-tab--display-idle-timer)
-  (unless elscreen-tab--display-idle-timer
+  (unless (and elscreen-tab--display-idle-timer (= elscreen-tab--last-screen-id (elscreen-get-current-screen)))
+    (elscreen-tab--debug-log "elscreen-tab--display-idle-timer : %s" elscreen-tab--display-idle-timer)
     (setq elscreen-tab--display-idle-timer
       (run-with-idle-timer elscreen-tab-delay-of-updating-display nil 'elscreen-tab--update-buffer))))
 


### PR DESCRIPTION
- To avoid freeze, refresh display at idle time

----

- Frequency of update request by `elscreen.el` is too much https://github.com/knu/elscreen/issues/36 , and `elscreen-screen-update-hook`  contained several methods such as `elscreen-menu-bar-update` when freeze of display occurs. `(setq elscreen-screen-update-hook nil)` can fix this issue when the freeze occur.
